### PR TITLE
Make react-native a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/Kureev/react-native-blur/issues"
   },
   "homepage": "https://github.com/Kureev/react-native-blur",
-  "dependencies": {
-    "react-native": "^0.4"
+  "peerDependencies": {
+    "react-native": "^0.4.0"
   }
 }


### PR DESCRIPTION
I think that is standard, and should play better with more setups since you never want more than one react instance (e.g. if versions disagree)