### PR TITLE
Support for React 0.4.3+

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,21 +1,27 @@
-var createComponent = require('createReactNativeComponentClass');
-var ReactNativeViewAttributes = require('ReactNativeViewAttributes');
-var merge = require('merge');
+var React = require('react-native');
+var { requireNativeComponent } = React;
 
-var validAttributes = merge(
-  ReactNativeViewAttributes.UIView, {
-  blurType: true
-});
+var BlurView = React.createClass({
+  propTypes: {
+    blurType: React.PropTypes.string,
+  },
 
-var BlurView = createComponent({
-  validAttributes: validAttributes,
-  uiViewClassName: 'BlurView'
+  render() {
+    return <NativeBlurView {...this.props} />;
+  }
 });
+var NativeBlurView = requireNativeComponent('BlurView', BlurView);
 
-var VibrancyView = createComponent({
-  validAttributes: validAttributes,
-  uiViewClassName: 'VibrancyView'
+var VibrancyView = React.createClass({
+  propTypes: {
+    blurType: React.PropTypes.string,
+  },
+
+  render() {
+    return <NativeVibrancyView {...this.props} />;
+  }
 });
+var NativeVibrancyView = requireNativeComponent('VibrancyView', VibrancyView);
 
 // What have you expected to see here? :D
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/Kureev/react-native-blur",
   "dependencies": {
-    "react-native": "^0.4"
+    "react-native": "^0.4.3"
   }
 }


### PR DESCRIPTION
React 0.4.3 no longer features `createReactIOSNativeComponentClass` and `ReactIOSViewAttributes`.   Now we should use `requireNativeComponent`. ([Reference](http://www.reactnative.com/react-native-0-4-3/))
