### PR TITLE
RN Version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-blur",
-  "version": "0.4.2",
+  "version": "0.5.1",
   "description": "React Native Blur component",
   "main": "index.js",
   "scripts": {
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/Kureev/react-native-blur",
   "dependencies": {
-    "react-native": "^0.4.3"
+    "react-native": ">=0.4.3"
   }
 }


### PR DESCRIPTION
Bump the version to 0.5.1 (will need a new tag) and update the react-native requirement to `>=0.4.3` so that it will work with 0.5.0, etc.