### PR TITLE
Android BlurView now uses findNodeHandle internally, so viewRef can just be the ref from RN.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ android {
 
 ```javascript
 import React, { Component } from 'react';
-import { View, Image, Text, findNodeHandle, StyleSheet } from 'react-native';
+import { View, Image, Text, StyleSheet } from 'react-native';
 import { BlurView } from 'react-native-blur';
 
 export default class Menu extends Component {
@@ -84,7 +84,8 @@ export default class Menu extends Component {
   }
 
   imageLoaded() {
-    this.setState({ viewRef: findNodeHandle(this.backgroundImage) });
+    // Only set the viewRef when we are ready to blur the image
+    this.setState({ viewRef: this.backgroundImage });
   }
 
   render() {
@@ -150,7 +151,7 @@ export default class Menu extends Component {
 
 ### Android
 
-Android uses the [500px-android-blur](https://github.com/500px/500px-android-blur) library, which works by blurring a referenced view. This means that you must wait until the view you want to blur is rendered. You then use `findNodeHandle` to get a reference to that view, and pass that reference to the `BlurView` as the `viewRef` prop. Take a look at [the BlurView example](#blurview) to see how it works.
+Android uses the [500px-android-blur](https://github.com/500px/500px-android-blur) library, which works by blurring a referenced view. This means that you must wait until the view you want to blur is rendered, and then pass the reference to the `BlurView` as the `viewRef` prop. Take a look at [the BlurView example](#blurview) to see how it works.
 
 The Android library introduces some limitations:
 

--- a/android/src/main/java/com/cmcewen/blurview/BlurViewManager.java
+++ b/android/src/main/java/com/cmcewen/blurview/BlurViewManager.java
@@ -48,9 +48,9 @@ public class BlurViewManager extends SimpleViewManager<BlurringView> {
         view.setDownsampleFactor(factor);
     }
 
-    @ReactProp(name = "viewRef")
-    public void setViewRef(BlurringView view, int viewRef) {
-        View viewToBlur = context.getCurrentActivity().findViewById(viewRef);
+    @ReactProp(name = "nodeHandle")
+    public void setNodeHandle(BlurringView view, int nodeHandle) {
+        View viewToBlur = context.getCurrentActivity().findViewById(nodeHandle);
 
         if (viewToBlur != null) {
             view.setBlurredView(viewToBlur);

--- a/examples/Basic/index.android.js
+++ b/examples/Basic/index.android.js
@@ -7,7 +7,6 @@ import React, { Component } from 'react';
 import {
   AppRegistry,
   Image,
-  findNodeHandle,
   StyleSheet,
   Text,
   View,
@@ -33,12 +32,10 @@ class Basic extends Component {
   }
 
   imageLoaded() {
-    // Workaround for a tricky race condition on initial load.
-    InteractionManager.runAfterInteractions(() => {
-      setTimeout(() => {
-        this.setState({ viewRef: findNodeHandle(this.refs.backgroundImage) });
-      }, 500);
-    });
+    // Workaround for a tricky race condition on initial load
+    setTimeout(() => {
+      this.setState({ viewRef: this.backgroundImage });
+    }, 500);
   }
 
   _onChange(selected) {
@@ -58,14 +55,14 @@ class Basic extends Component {
           viewRef={this.state.viewRef}
           style={styles.blurView}
 
-          blurRadius={9}
+          blurAmount={10}
           blurType={this.state.blurType}
 
           // The following props are also available on Android:
-
-          // blurRadius={20}
-          // downsampleFactor={10}
-          // overlayColor={'rgba(0, 0, 255, .6)'}   // set a blue overlay
+          //
+          // blurAmount=10                          // Matches blurAmount on iOS
+          // downsampleFactor={10}                  // Shrink the image before blurring (we do this by default)
+          // overlayColor={'rgba(0, 0, 255, .6)'}   // Set a blue overlay
         />}
 
         <Text style={[styles.text, { color: tintColor[0] }]}>
@@ -83,8 +80,8 @@ class Basic extends Component {
           childText={BLUR_TYPES}
           orientation='horizontal'
           selectedPosition={this.state.activeSegment}
-          onChange={this._onChange.bind(this)} />
-
+          onChange={this._onChange.bind(this)}
+        />
       </View>
     )
   }
@@ -95,7 +92,7 @@ class Basic extends Component {
         <Image
           source={require('./bgimage.jpeg')}
           style={styles.image}
-          ref={'backgroundImage'}
+          ref={(i) => { this.backgroundImage = i; }}
           onLoadEnd={this.imageLoaded.bind(this)} />
 
         { this.state.showBlur ? this.renderBlurView() : null }

--- a/examples/Basic/yarn.lock
+++ b/examples/Basic/yarn.lock
@@ -2920,11 +2920,11 @@ react-devtools-core@^2.0.8:
     ws "^2.0.3"
 
 "react-native-blur@file:../../":
-  version "2.0.0"
+  version "3.0.0-alpha"
 
-react-native-segmented-android@^1.0.4:
+react-native-segmented-android@sooth-sayer/react-native-segmented-android:
   version "1.0.4"
-  resolved "https://registry.yarnpkg.com/react-native-segmented-android/-/react-native-segmented-android-1.0.4.tgz#223424ab2b6b31acdd90be1ff3d49953a0df2c1d"
+  resolved "https://codeload.github.com/sooth-sayer/react-native-segmented-android/tar.gz/e674a9c0d06f40eec03cc94db106726e2916d671"
 
 react-native@0.43.3:
   version "0.43.3"


### PR DESCRIPTION
I need this mainly for my `react-native-web` PR (#190), because it would be great if we can just call `setNativeProps` on the actual ref, instead of being passed the underlying node.

The other reason this is good is because the developer no longer has to worry about calling `findNodeHandle`, and we can make sure that `findNodeHandle` is being called outside the render cycle (otherwise you get a warning).