### PR TITLE
iOS+Android - animating BlurView

### DIFF
--- a/ios/BlurView.m
+++ b/ios/BlurView.m
@@ -127,6 +127,7 @@
 
 - (void)updateBlurEffect
 {
+  self.blurEffectView.effect = nil;
   UIBlurEffectStyle style = [self blurEffectStyle];
   self.blurEffect = [BlurEffectWithAmount effectWithStyle:style andBlurAmount:self.blurAmount];
   self.blurEffectView.effect = self.blurEffect;

--- a/src/BlurView.android.js
+++ b/src/BlurView.android.js
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import {
   View,
@@ -16,7 +16,7 @@ const OVERLAY_COLORS = {
 
 class BlurView extends Component {
   componentDidMount() {
-    DeviceEventEmitter.addListener('ReactNativeBlurError', (message) => {
+    DeviceEventEmitter.addListener('ReactNativeBlurError', message => {
       throw new Error(`[ReactNativeBlur]: ${message}`);
     });
   }
@@ -25,20 +25,20 @@ class BlurView extends Component {
     DeviceEventEmitter.removeAllListeners('ReactNativeBlurError');
   }
 
-  overlayColor() {
-    if (this.props.overlayColor != null) {
-      return this.props.overlayColor;
+  overlayColor(props) {
+    if (props.overlayColor != null) {
+      return props.overlayColor;
     }
-    return OVERLAY_COLORS[this.props.blurType] || OVERLAY_COLORS.dark;
+    return OVERLAY_COLORS[props.blurType] || OVERLAY_COLORS.dark;
   }
 
-  blurRadius() {
-    const {blurRadius, blurAmount} = this.props;
+  blurRadius(props) {
+    const { blurRadius, blurAmount } = props;
 
     if (blurRadius != null) {
       if (blurRadius > 25) {
         throw new Error(
-          `[ReactNativeBlur]: blurRadius cannot be greater than 25! (was: ${blurRadius})`,
+          `[ReactNativeBlur]: blurRadius cannot be greater than 25! (was: ${blurRadius})`
         );
       }
       return blurRadius;
@@ -54,24 +54,38 @@ class BlurView extends Component {
     return equivalentBlurRadius;
   }
 
-  downsampleFactor() {
-    const {downsampleFactor, blurRadius} = this.props;
+  downsampleFactor(props) {
+    const { downsampleFactor, blurRadius } = props;
     if (downsampleFactor != null) {
       return downsampleFactor;
     }
     return blurRadius;
   }
 
+  setNativeProps = nativeProps => {
+    if (this._root) {
+      console.log(nativeProps)
+      this._root.setNativeProps({
+        ...nativeProps,
+        blurRadius:this.blurRadius(nativeProps),
+        downsampleFactor:this.downsampleFactor(nativeProps),
+        overlayColor:this.overlayColor(nativeProps)
+      });
+    }
+  };
+
   render() {
-    const {style} = this.props;
+    const { style } = this.props;
 
     return (
       <NativeBlurView
-        blurRadius={this.blurRadius()}
-        downsampleFactor={this.downsampleFactor()}
-        overlayColor={this.overlayColor()}
+        ref={e => (this._root = e)}
+        blurRadius={this.blurRadius(this.props)}
+        downsampleFactor={this.downsampleFactor(this.props)}
+        overlayColor={this.overlayColor(this.props)}
         pointerEvents="none"
-        style={StyleSheet.compose(styles.transparent, style)}>
+        style={StyleSheet.compose(styles.transparent, style)}
+      >
         {this.props.children}
       </NativeBlurView>
     );
@@ -79,7 +93,7 @@ class BlurView extends Component {
 }
 
 const styles = StyleSheet.create({
-  transparent: {backgroundColor: 'transparent'},
+  transparent: { backgroundColor: 'transparent' },
 });
 
 BlurView.propTypes = {

--- a/src/BlurView.android.js
+++ b/src/BlurView.android.js
@@ -64,12 +64,15 @@ class BlurView extends Component {
 
   setNativeProps = nativeProps => {
     if (this._root) {
-      console.log(nativeProps)
+      const props = {
+        ...this.props,
+        ...nativeProps
+      }
       this._root.setNativeProps({
         ...nativeProps,
-        blurRadius:this.blurRadius(nativeProps),
-        downsampleFactor:this.downsampleFactor(nativeProps),
-        overlayColor:this.overlayColor(nativeProps)
+        blurRadius:this.blurRadius(props),
+        downsampleFactor:this.downsampleFactor(props),
+        overlayColor:this.overlayColor(props)
       });
     }
   };


### PR DESCRIPTION
Allow animations to update blur view.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

In order for the blur view to react to changes via animated props, the effect needed to be set to nil just before the new one is created. Without this change, the blur view would not update.

This also required changes on android, as I required a setNativeProps function to be exposed, it was already exposed on iOS

## Test Plan

Clone for an example. 

https://github.com/kyle-ssg/reanimated2-experiments


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅   |
| Android |    ✅    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md` - N/A
- [ ] I mentioned this change in `CHANGELOG.md` -There isn't a CHANGELOG.md..
- [ ] I updated the typed files (TS and Flow) - N/A
- [ ] I added a sample use of the API in the example project (`example/App.js`) - N/A


<img width="350" align="left" src="http://g.recordit.co/BJmtskJoNW.gif"/>
<img width="350" align="left" src="https://recordit.co/xjvDy9Tpt4.gif"/>
