### PR TITLE
Do not crash when the main activity is unavailable

### DIFF
--- a/android/src/main/java/com/cmcewen/blurview/BlurViewManager.java
+++ b/android/src/main/java/com/cmcewen/blurview/BlurViewManager.java
@@ -5,11 +5,8 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.facebook.react.uimanager.ViewGroupManager;
-import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.annotations.ReactProp;
-
-import java.util.Objects;
 
 import javax.annotation.Nonnull;
 
@@ -32,14 +29,17 @@ class BlurViewManager extends ViewGroupManager<BlurView> {
     @Override
     public @Nonnull BlurView createViewInstance(@Nonnull ThemedReactContext ctx) {
         BlurView blurView = new BlurView(ctx);
-        View decorView = Objects.requireNonNull(ctx.getCurrentActivity()).getWindow().getDecorView();
-        ViewGroup rootView = decorView.findViewById(android.R.id.content);
-        Drawable windowBackground = decorView.getBackground();
-        blurView.setupWith(rootView)
-            .setFrameClearDrawable(windowBackground)
-            .setBlurAlgorithm(new RenderScriptBlur(ctx))
-            .setBlurRadius(defaultRadius)
-            .setHasFixedTransformationMatrix(false);
+        Activity currentActivity = ctx.getCurrentActivity();
+        if (currentActivity != null) {
+            View decorView = currentActivity.getWindow().getDecorView();
+            ViewGroup rootView = decorView.findViewById(android.R.id.content);
+            Drawable windowBackground = decorView.getBackground();
+            blurView.setupWith(rootView)
+                .setFrameClearDrawable(windowBackground)
+                .setBlurAlgorithm(new RenderScriptBlur(ctx))
+                .setBlurRadius(defaultRadius)
+                .setHasFixedTransformationMatrix(false);
+        }
         return blurView;
     }
 

--- a/android/src/main/java/com/cmcewen/blurview/BlurViewManager.java
+++ b/android/src/main/java/com/cmcewen/blurview/BlurViewManager.java
@@ -1,5 +1,6 @@
 package com.cmcewen.blurview;
 
+import android.app.Activity;
 import android.graphics.drawable.Drawable;
 import android.view.View;
 import android.view.ViewGroup;


### PR DESCRIPTION
# Summary

The React Native application context has a method for obtaining the current Android activity, but this sometimes returns null. We believe this happens due to a race condition between the Javascript engine and the native code, but we aren't completely sure. What we do know is that this situation happens in the wild, since it shows up in our Bugsnag reports.

The fix is the leave the BlurView native component uninitialized in these cases. This prevents it from rendering anything, but that's preferable to crashing the whole app.

<img width="1045" alt="Screen Shot 2020-09-29 at 8 31 19 AM" src="https://user-images.githubusercontent.com/276214/94627392-3c87eb80-0272-11eb-97a2-c378fec8647b.png">

## Test Plan

Since we don't have a reproduction case for the crash, we intend to deploy these changes in the next release of our App, and then see if our Bugsnag reports are any cleaner.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
