### PR TITLE
Fix multiple blur view issues

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,5 +43,5 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.eightbitlab:blurview:1.6.3'
+    implementation 'com.eightbitlab:blurview:1.6.6'
 }


### PR DESCRIPTION
Dimezis just released a fix with https://github.com/Dimezis/BlurView/issues/110 to address app crashes on Android when multiple blur views are in place. This PR includes the most recent version from https://github.com/Dimezis/BlurView into this project.