### PR TITLE
added mavenCentral() for gradle builds

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,6 +8,7 @@ buildscript {
     // module dependency in an application project.
     if (project == rootProject) {
         repositories {
+            mavenCentral()
             google()
             jcenter()
         }
@@ -36,6 +37,7 @@ android {
 }
 
 repositories {
+    mavenCentral()
     google()
     jcenter()
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,7 +10,6 @@ buildscript {
         repositories {
             mavenCentral()
             google()
-            jcenter()
         }
 
         dependencies {
@@ -39,7 +38,6 @@ android {
 repositories {
     mavenCentral()
     google()
-    jcenter()
 }
 
 dependencies {


### PR DESCRIPTION
As jCenter is shutting down so adding mavenCentral() so that gradle builds fail