### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/react-native-blur.podspec
+++ b/react-native-blur.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
   s.homepage      = "https://github.com/react-native-community/react-native-blur"
   s.source        = { :git => "https://github.com/react-native-community/react-native-blur.git" }
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
# Summary

Latest Xcode 12 fails to build while without a module to depend on React-Core directly hence this change is necessary for all native modules on iOS. This change requires React Native 0.60.2 or newer. For more details please check: facebook/react-native#29633 (comment)