### PR TITLE
fix(android): build issue on compileSdkVersion < 31

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/blurview/BlurViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/blurview/BlurViewManager.java
@@ -37,7 +37,7 @@ class BlurViewManager extends ViewGroupManager<BlurView> {
       .getDecorView();
     ViewGroup rootView = decorView.findViewById(android.R.id.content);
     Drawable windowBackground = decorView.getBackground();
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+    if (Build.VERSION.SDK_INT >= 31) {
       blurView
         .setupWith(rootView, new RenderEffectBlur())
         .setFrameClearDrawable(windowBackground)


### PR DESCRIPTION
The `Build.VERSION_CODES.S` variable is not available in `compileSdkVersion` lower than 31, which forces everyone to update to `compileSdkVersion: 31`. Even though the latest React Native uses 31, there are packages forcing apps to use lower sdk versions due compatibility issues

cc @Titozzz 