### PR TITLE
Fixed blurEffectStyle usage on tvOS target

### DIFF
--- a/ios/BlurView.m
+++ b/ios/BlurView.m
@@ -90,7 +90,7 @@
     if ([self.blurType isEqual: @"prominent"]) return UIBlurEffectStyleProminent;
   #endif
     
-  #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* __IPHONE_13_0 */
+  #if !TARGET_OS_TV && defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* __IPHONE_13_0 */
     // Adaptable blur styles
     if ([self.blurType isEqual: @"chromeMaterial"]) return UIBlurEffectStyleSystemChromeMaterial;
     if ([self.blurType isEqual: @"material"]) return UIBlurEffectStyleSystemMaterial;


### PR DESCRIPTION
Disabled usage of certain UIBlurEffectStyles on tvOS because not supported.