### PR TITLE
feat(iOS): transparent blur type

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ cd ios && pod install
 | `extraDark` | extra dark blur type (tvOS only)
 | `regular` | regular blur type (iOS 10+ and tvOS only)
 | `prominent` |  prominent blur type (iOS 10+ and tvOS only)
+| `transparent` |  transparent blur type (iOS 10+ and tvOS only)
 
 #### blurType (iOS 13 only)
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -23,7 +23,7 @@ import {
 
 const blurTypeValues =
   Platform.OS === 'ios'
-    ? ['xlight', 'light', 'dark', 'regular', 'prominent']
+    ? ['xlight', 'light', 'dark', 'regular', 'prominent', 'transparent']
     : ['xlight', 'light', 'dark'];
 
 const Blurs = () => {

--- a/ios/BlurView.mm
+++ b/ios/BlurView.mm
@@ -131,6 +131,7 @@ using namespace facebook::react;
 
 - (UIBlurEffectStyle)blurEffectStyle
 {
+  if ([self.blurType isEqual: @"transparent"]) return UIBlurEffectStyleDark;
   if ([self.blurType isEqual: @"xlight"]) return UIBlurEffectStyleExtraLight;
   if ([self.blurType isEqual: @"light"]) return UIBlurEffectStyleLight;
   if ([self.blurType isEqual: @"dark"]) return UIBlurEffectStyleDark;
@@ -183,6 +184,12 @@ using namespace facebook::react;
   UIBlurEffectStyle style = [self blurEffectStyle];
   self.blurEffect = [BlurEffectWithAmount effectWithStyle:style andBlurAmount:self.blurAmount];
   self.blurEffectView.effect = self.blurEffect;
+
+  if ([self.blurType isEqual: @"transparent"]) {
+    for (UIView *subview in self.blurEffectView.subviews) {
+      subview.backgroundColor = [UIColor clearColor];
+    }
+  }
 }
 
 - (void)updateFallbackView

--- a/src/components/BlurView.ios.tsx
+++ b/src/components/BlurView.ios.tsx
@@ -6,6 +6,7 @@ type BlurType =
   | 'dark'
   | 'light'
   | 'xlight'
+  | 'transparent'
   | 'prominent'
   | 'regular'
   | 'extraDark'

--- a/src/fabric/BlurViewNativeComponent.ts
+++ b/src/fabric/BlurViewNativeComponent.ts
@@ -10,6 +10,7 @@ interface NativeProps extends ViewProps {
     | 'dark'
     | 'light'
     | 'xlight'
+    | 'transparent'
     | 'prominent'
     | 'regular'
     | 'extraDark'

--- a/src/fabric/VibrancyViewNativeComponent.ts
+++ b/src/fabric/VibrancyViewNativeComponent.ts
@@ -11,6 +11,7 @@ interface NativeProps extends ViewProps {
     | 'light'
     | 'xlight'
     | 'prominent'
+    | 'transparent'
     | 'regular'
     | 'extraDark'
     | 'chromeMaterial'


### PR DESCRIPTION
Hi there :wave: hope you're doing well

I've been looking for a way to implement Twitter-like navbar:

<img width="380" src="https://user-images.githubusercontent.com/17552441/204909415-f78ed7ff-bfe9-4afb-b76f-a08b58d7cb7d.jpeg">

and it seems like it's not possible with current blur types.

So here's what I came up with:  transparent blur type applies `UIBlurEffectStyleDark` (it doesn't matter dark or light) style and overrites `backgroundColor` property for each subview to transparent color. Works the same regardless of the selected system color scheme

| blurType={'dark'} | blurType={'transparent'} |
| ----------- | ----------- | 
| <img width="446" alt="before" src="https://user-images.githubusercontent.com/17552441/204902381-e96222dc-b77f-4b08-90fb-6c52f7638475.png"> | <img width="443" alt="after" src="https://user-images.githubusercontent.com/17552441/204902427-472a0fd4-5ed9-4eca-aaa3-cbe6fd5a3154.png"> |

Probably it solves #474 and #465

Tested both `BlurView` and `VibrancyView` on iOS simulator including example project.
Update `README.md` and example