### PR TITLE
feat: Add support for RN 0.72

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,6 +28,7 @@ def getExtOrIntegerDefault(name) {
 }
 
 android {
+  namespace 'com.reactnativecommunity.blurview'
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
 
   defaultConfig {


### PR DESCRIPTION
Adds `namespace` to `build.gradle` (this is required by Gradle 8, which RN 0.72 uses)