### PR TITLE
Do not crash when the main activity is unavailable

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/blurview/BlurViewManagerImpl.java
+++ b/android/src/main/java/com/reactnativecommunity/blurview/BlurViewManagerImpl.java
@@ -1,5 +1,6 @@
 package com.reactnativecommunity.blurview;
 
+import android.app.Activity;
 import android.view.View;
 import com.facebook.react.uimanager.ThemedReactContext;
 
@@ -18,14 +19,18 @@ class BlurViewManagerImpl {
 
   public static @Nonnull BlurView createViewInstance(@Nonnull ThemedReactContext ctx) {
     BlurView blurView = new BlurView(ctx);
-    View decorView = Objects
-      .requireNonNull(ctx.getCurrentActivity())
-      .getWindow()
-      .getDecorView();
-    blurView
-      .setupWith(decorView.findViewById(android.R.id.content))
-      .setFrameClearDrawable(decorView.getBackground())
-      .setBlurRadius(defaultRadius);
+
+    Activity currentActivity = ctx.getCurrentActivity();
+    if (currentActivity != null) {
+      View decorView = Objects
+        .requireNonNull(ctx.getCurrentActivity())
+        .getWindow()
+        .getDecorView();
+      blurView
+        .setupWith(decorView.findViewById(android.R.id.content))
+        .setFrameClearDrawable(decorView.getBackground())
+        .setBlurRadius(defaultRadius);
+    }
     return blurView;
   }
 


### PR DESCRIPTION
## Note
This is a dupe of [this other PR](https://github.com/Kureev/react-native-blur/pull/399), which is ready to merge but has merge conflicts that I can't solve because is not on my fork. so since I need this fix ASAP, I'm pushing the same fix on an up to date branch with no conflicts.

## Summary

The React Native application context has a method for obtaining the current Android activity, but this sometimes returns null. We believe this happens due to a race condition between the JavaScript engine and the native code, but we aren't completely sure. What we do know is that this situation happens in the wild, since it shows up in our Bugsnag reports.

The fix is to leave the BlurView native component uninitialized in these cases. This prevents it from rendering anything, but that's preferable to crashing the whole app.

![Screen Shot](https://user-images.githubusercontent.com/276214/94627392-3c87eb80-0272-11eb-97a2-c378fec8647b.png)

## Test Plan

Since we don't have a reproduction case for the crash, we intend to deploy these changes in the next release of our App and then see if our Bugsnag reports are any cleaner.

## Compatibility

| OS     | Implemented |
|--------|-------------|
| iOS    | ✅          |
| Android| ✅          |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in README.md
- [ ] I mentioned this change in CHANGELOG.md
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (example/App.js)
