### PR TITLE
feat: add visionOS support

### DIFF
--- a/react-native-blur.podspec
+++ b/react-native-blur.podspec
@@ -1,8 +1,7 @@
 require "json"
 
+new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
-# folly_version = '2021.06.28.00-v2'
-folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
 Pod::Spec.new do |s|
   s.name         = "react-native-blur"
@@ -12,26 +11,33 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => "10.0", :tvos => "11.0" }
+  s.platforms    = { :ios => "10.0", :tvos => "11.0", :visionos => "1.0" }
   s.source       = { :git => "https://github.com/react-native-community/react-native-blur.git" }
 
   s.source_files = "ios/**/*.{h,m,mm}"
 
-  s.dependency "React-Core"
+  if defined?(install_modules_dependencies()) != nil 
+    install_modules_dependencies(s)
+  else 
+    # Don't install the dependencies when we run `pod install` in the old architecture.
+    if new_arch_enabled then
+      folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
-  # Don't install the dependencies when we run `pod install` in the old architecture.
-  if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
-        "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-        "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
-    }
+      s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
+      s.pod_target_xcconfig    = {
+          "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
+          "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
+      }
 
-    s.dependency "React-RCTFabric"
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
+      s.dependency "React-RCTFabric"
+      s.dependency "React-Codegen"
+      s.dependency "RCT-Folly"
+      s.dependency "RCTRequired"
+      s.dependency "RCTTypeSafety"
+      s.dependency "ReactCommon/turbomodule/core"
+    end
+    else
+      s.dependency "React-Core"
+    end
   end
 end


### PR DESCRIPTION
This PR adds visionOS support for this library. Having `BlurView` is essential for designing and creating apps for this platform. 

It also adds `install_modules_dependencies` which properly configures the iOS dependencies in the podspec for RN 0.70+ (as this is required to make visionOS work).

Reference: https://github.com/callstack/react-native-slider/pull/556 by @cipolleschi

### Demo

https://github.com/Kureev/react-native-blur/assets/52801365/2da6b94c-c954-4d50-aa35-62253dda9423

