### PR TITLE
fix: Fix react-native 0.73/0.74 build by specifying `namespace`

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,6 +29,7 @@ def getExtOrIntegerDefault(name) {
 
 android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
+  namespace "com.reactnativecommunity.blurview"
 
   defaultConfig {
     minSdkVersion getExtOrIntegerDefault('minSdkVersion')


### PR DESCRIPTION
This is required now since AGP 8.